### PR TITLE
Replace "Wikimedia Labs" with "Toolforge"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,7 +80,7 @@
   <hr style="border: 0.5px solid #a2a9b1"/>
 
   <div style="text-align: center; margin: 1em;">
-    Hosted by Wikimedia Labs &amp; written in <a href="https://python.org">Python 3</a>
+    Hosted by <a href="https://tools.wmflabs.org/">Toolforge</a> &amp; written in <a href="https://python.org">Python 3</a>
   </div>
   </body>
 </html>


### PR DESCRIPTION
The "Labs" product name has been replaced with either "Cloud VPS" or "Toolforge" depending on the actual sub-product.